### PR TITLE
FEAT: history 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "kuphilweb_v2",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^4.29.25",
+        "@tanstack/react-query-devtools": "^4.29.25",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3615,6 +3617,75 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz",
+      "integrity": "sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.29.25",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.25.tgz",
+      "integrity": "sha512-DI4y4VC6Uw4wlTpOocEXDky69xeOScME1ezLKsj+hOk7DguC9fkqXtp6Hn39BVb9y0b5IBrY67q6kIX623Zj4Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.29.25",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.25.tgz",
+      "integrity": "sha512-c1+Ezu+XboYrdAMdusK2fTdRqXPMgPAnyoTrzHOZQqr8Hqz6PNvV9DSKl8agUo6nXX4np7fdWabIprt+838dLg==",
+      "dependencies": {
+        "@tanstack/query-core": "4.29.25",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.29.25",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.25.tgz",
+      "integrity": "sha512-XlrGUqmjv1O+6Ny23rAiyNSWYKep90SKT3IixDQRnIuTGaZej+hVCOh7wZSxq6qkzadIvsblc4SLtyJsOiIXBQ==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.29.25",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
@@ -6198,6 +6269,20 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js": {
       "version": "3.31.0",
@@ -9736,6 +9821,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.15.tgz",
+      "integrity": "sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -14892,6 +14988,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -15977,6 +16078,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/superjson": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.1.tgz",
+      "integrity": "sha512-AVH2eknm9DEd3qvxM4Sq+LTCkSXE2ssfh1t11MHMXyYXFQyQ1HLgVvV+guLTsaQnJU3gnaVo34TohHPulY/wLg==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -16658,6 +16770,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "proxy": "http://13.124.56.187:8080/",
   "dependencies": {
+    "@tanstack/react-query": "^4.29.25",
+    "@tanstack/react-query-devtools": "^4.29.25",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,34 +1,43 @@
 import "./App.css";
-import React from "react";
+
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import { createGlobalStyle } from 'styled-components';
-import reset from 'styled-reset';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import Board from './Pages/Board';
+import BoardCreate from './Pages/BoardCreate';
+import BoardRead from './Pages/BoardRead';
+import History from './Pages/History';
 import Home from "./Pages/Home";
 import Introduce from "./Pages/Introduce";
 import Lab from './Pages/Lab'
 import Playground from './Pages/Playground';
+import React from "react";
 import Test from './Pages/Test';
-import Board from './Pages/Board';
-import BoardRead from './Pages/BoardRead';
-import BoardCreate from './Pages/BoardCreate';
+import { createGlobalStyle } from 'styled-components';
+import reset from 'styled-reset';
+
+const queryClient = new QueryClient()
 
 function App() {
   return (
-    <div className="App">
-      <GlobalStyles />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/introduce" element={<Introduce /> }/>
-          <Route path="/test" element={<Test />} />
-          <Route path="/playground" element={<Playground />} />
-          <Route path="/lab" element={<Lab />} />
-          <Route path="/board" element={<Board />} />
-          <Route path="/board/read/:id" element={<BoardRead />} />
-          <Route path="/board/create" element={<BoardCreate />} />
-        </Routes>
-      </BrowserRouter>
-    </div>
+    <QueryClientProvider client={queryClient}>
+      <div className="App">
+        <GlobalStyles />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/introduce" element={<Introduce /> }/>
+            <Route path="history" element={<History />}/>
+            <Route path="/test" element={<Test />} />
+            <Route path="/playground" element={<Playground />} />
+            <Route path="/lab" element={<Lab />} />
+            <Route path="/board" element={<Board />} />
+            <Route path="/board/read/:id" element={<BoardRead />} />
+            <Route path="/board/create" element={<BoardCreate />} />
+          </Routes>
+        </BrowserRouter>
+      </div>
+    </QueryClientProvider>
   );
 }
 

--- a/src/Components/history/HistoryContent.js
+++ b/src/Components/history/HistoryContent.js
@@ -1,0 +1,117 @@
+import React from "react";
+import styled from 'styled-components';
+import { useQuery } from '@tanstack/react-query'
+
+const HistoryContent = () => {
+    const YearArr = [2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023];
+
+
+    // Dummy Data로 형태 잡기
+    // 실제 DB에서 가져올 때는 Typescript로 Migration해서 type을 정의해 전체 -> 연도 -> 해당연도 연혁 순으로 Array에 담아준 뒤 활용할 계획
+    // 혹은 {year: 2003, date: '02월', text: '세레나데 창단'} 형식으로 가져온다면 filter를 활용해서 나열할 계획
+
+    
+    const getComments = async () => {
+        return await (await fetch("https://jsonplaceholder.typicode.com/posts/1/comments")).json();
+      };
+    
+    
+    const { data, isLoading, error } = useQuery(["comments"], getComments);
+
+    if (isLoading) return <div>'Loading...'</div>;
+
+    if (error) return <div>'Error..'</div>
+    
+    if(data !== undefined) {
+      let comments = data.map(
+        (comment) =>
+        <WrapComment>
+            <Date>00일</Date>
+            <Text key={comment.name}>{comment.name}</Text>
+        </WrapComment>);
+       
+      return (
+        <>
+            <WrapContent>
+                {YearArr.map((v) => (
+                    <>
+                        <Year key={v}><a name={v}>{v}</a></Year>
+                        <WrapComments>{comments}</WrapComments>
+                    </>
+                 ))}
+            </WrapContent>
+        </>
+      )
+    }
+    
+    return(
+        <WrapContent/>
+    )
+}
+
+export default HistoryContent;
+
+const WrapContent = styled.section`
+`
+
+const WrapComments = styled.div`
+    height: 150px;
+    margin: 30px 0 80px 20px;
+    padding: 5px 0 5px 10px;
+    border-left: 3px solid #ccd0d3;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    @media screen and (max-width: 767px){
+        height: auto;
+        padding-left: 0;
+        margin: 10px 0 80px 0px;
+        border: none;
+    } 
+`
+
+const WrapComment = styled.div`
+    display: flex;
+
+    @media screen and (max-width: 767px){
+        height: 35px;
+        flex-direction: column;
+        margin: 10px 0;
+        justify-content: space-between;
+    } 
+`
+
+const Year = styled.p`
+    font-size: 30px;
+    font-weight: bold;
+    text-align: left;
+
+    @media screen and (max-width: 767px){
+        font-size: 16px;
+        text-align: center;
+    } 
+`
+
+const Date = styled.p`
+    font-size: 15px;
+    width: 100px;
+    font-weight: bold;
+    margin: 0 10px 0 20px;
+    text-align: left;
+
+    @media screen and (max-width: 767px){
+        font-size: 13px;
+        text-align: center;
+        margin: 0;
+        width: auto;
+    } 
+`
+
+const Text = styled.p`
+    font-size: 15px;
+
+    @media screen and (max-width: 767px){
+        font-size: 13px;
+    } 
+`

--- a/src/Pages/History.js
+++ b/src/Pages/History.js
@@ -1,0 +1,107 @@
+import React, {useState} from "react";
+
+import Footer from '../Components/footer/Footer';
+import Header from '../Components/header/Header';
+import HistoryContent from "../Components/history/HistoryContent";
+import TitleGradient from '../Components/TitleGradient';
+import styled from 'styled-components';
+
+//api 생성 후에는 map으로 받아서 뿌려준다.
+
+const History = () => {
+    return(
+        <>
+            <Wrap>
+                <Header/>
+                <Contents>
+                    <TitleGradient
+                            title="소개"
+                            title2="연혁"
+                            explain={"2003년 창단 이후의 활동을 살펴보세요."}
+                            link="/introduce"
+                            link2="/history"
+                            color="linear-gradient(91.48deg, rgba(255, 224, 196, 0.44) 0%, #FFFBD9 100%)"
+                    />
+                    <MainContent>
+                        <SelectStartYear>
+                            <StartYearBtn><YearHref href="#2003">2003~</YearHref></StartYearBtn>
+                            <StartYearBtn className="subYear"><YearHref href='#2005'>2005~</YearHref></StartYearBtn>
+                            <StartYearBtn><YearHref href='#2010'>2010~</YearHref></StartYearBtn>
+                            <StartYearBtn className="subYear"><YearHref href='#2015'>2015~</YearHref></StartYearBtn>
+                            <StartYearBtn><YearHref href='#2020'>2020~</YearHref></StartYearBtn>
+                        </SelectStartYear>
+                        <HistoryContent/>
+                    </MainContent>
+                </Contents>
+            </Wrap>
+            <Footer/>
+        </>
+    )
+}
+
+const Wrap = styled.div`
+  width: 100%;
+  height: auto;
+
+  min-height: calc(100vh - 202px);
+  @media screen and (max-width: 767px){
+    min-height: calc(100vh - 152px);
+  }
+`;
+
+const Contents = styled.div`
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+  @media screen and (max-width: 767px){
+    max-width: 400px;
+  }
+`;
+
+const MainContent = styled.div`
+    width: 84%;
+    padding: 0 8%;
+    margin: 70px auto;
+
+    @media screen and (max-width: 767px){
+      padding: 0 5%;
+      margin-top: 30px;
+  } 
+`;
+
+const SelectStartYear = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  margin: 70px auto;
+
+  @media screen and (max-width: 767px){
+    margin-top: 30px;
+} 
+`
+
+const StartYearBtn = styled.button`
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+  font-size: 20px;
+  user-select: none;
+
+  &:hover {
+    color: gray;
+    font-weight: bold;
+  }
+
+  @media screen and (max-width: 767px){
+    ${props => props.className === "subYear" && `
+        display: none;
+    `};
+
+    font-size: 16px;
+}  
+`
+
+const YearHref = styled.a`
+  all: unset; 
+`
+
+export default History;


### PR DESCRIPTION
history 페이지 구현 완료.
세부적인 CSS는 나중에 협의 하에 수정 예정.

현재 a 코드로 페이지 내 이동 구현했으나 이벤트 처리로 수정할 수도 있음.

Dummy Data로 형태 잡아두었으나 실제 DB에서 가져올 때는 Typescript로 Migration해서 type을 정의해 전체 -> 연도 -> 해당연도 연혁 순으로 Array에 담아준 뒤 활용할 계획
혹은 {year: 2003, date: '02월', text: '세레나데 창단'} 형식으로 가져온다면 filter를 활용해서 나열할 계획