### PR TITLE
FIX: Archive Warning 해결

### DIFF
--- a/src/Components/archive/ConcertInfoContent.js
+++ b/src/Components/archive/ConcertInfoContent.js
@@ -54,7 +54,7 @@ const songtitleObject = concertData && concertData.songtitle;
 const songtitleKeys = songtitleObject && Object.keys(songtitleObject);
 
 const songtitleList = songtitleKeys && songtitleKeys.map((key, index) => (
-  <div key={index}>
+  <div key={`ST${index}`}>
     <Content style={{fontSize: "0.9em", color: "#444444"}}>{songtitleObject[key]}</Content>
   </div>
 ));
@@ -64,13 +64,13 @@ const composerObject = concertData && concertData.composer;
 const composerKeys = composerObject && Object.keys(composerObject);
 
 const composerList = composerKeys && composerKeys.map((key, index) => (
-  <div key={index}>
+  <div key={`C${index}`}>
     <Content style={{fontSize: "0.9em"}}>{composerObject[key]}</Content>
   </div>
 ));
 
 const pairedList = songtitleList && songtitleList.map((songtitle, index) => (
-  <div key={index}>
+  <div key={`P${index}`}>
     {composerList && composerList[index]}
     {songtitle}
     <br/>
@@ -147,7 +147,7 @@ const WrapInfo = styled.div`
     }
 `
 
-const Title = styled.p`
+const Title = styled.div`
     font-weight: bold;
     font-size: 1.5rem;
     margin-bottom: 20px;
@@ -169,7 +169,7 @@ const WrapContent = styled.div`
     }
 `
 
-const ContentTitle = styled.p`
+const ContentTitle = styled.div`
   font-weight: bold;
 
   @media screen and (max-width: 767px) {
@@ -178,7 +178,7 @@ const ContentTitle = styled.p`
   }
 `
 
-const Content = styled.p`
+const Content = styled.div`
   @media screen and (max-width: 767px) {
     text-align: center;
     font-size: 0.8rem;

--- a/src/Components/archive/PosterContent.jsx
+++ b/src/Components/archive/PosterContent.jsx
@@ -29,8 +29,8 @@ const PosterContent = () => {
             <PosterContainer>
             {page !== String(imageName.length) ? indexArr.map((elem, idx) => {
         return(
-            <Wrap onClick={() => navigate(`/concert/${imageName[Number(page)-1]-elem}`)}>
-                <WrapPoster key={idx} divWidth={divWidth} style={{backgroundImage: `url(../../../images/poster/poster_${imageName[Number(page)-1]-elem}.jpg)` }}/>
+            <Wrap key={idx} onClick={() => navigate(`/concert/${imageName[Number(page)-1]-elem}`)}>
+                <WrapPoster divWidth={divWidth} style={{backgroundImage: `url(../../../images/poster/poster_${imageName[Number(page)-1]-elem}.jpg)` }}/>
                 <WrapConcertNumber>
                     <ConcertNumber>제</ConcertNumber>
                     <ConcertNumber>{imageName[Number(page)-1]-elem}</ConcertNumber>
@@ -40,8 +40,8 @@ const PosterContent = () => {
             )}
             ) : indexArr2.map((elem, idx) => {
         return(
-            <Wrap onClick={() => navigate(`/concert/${imageName[Number(page)-1]-elem}`)}>
-                <WrapPoster key={idx} divWidth={divWidth} style={{backgroundImage: `url(../../../images/poster/poster_${imageName[Number(page)-1]-elem}.jpg)` }}/>
+            <Wrap key={idx} onClick={() => navigate(`/concert/${imageName[Number(page)-1]-elem}`)}>
+                <WrapPoster divWidth={divWidth} style={{backgroundImage: `url(../../../images/poster/poster_${imageName[Number(page)-1]-elem}.jpg)` }}/>
                 <WrapConcertNumber>
                     <ConcertNumber>제</ConcertNumber>
                     <ConcertNumber>{imageName[Number(page)-1]-elem}</ConcertNumber>


### PR DESCRIPTION
+ Warning: each child in a list should have a unique "key" prop.
=> map에 의해 반복되는 컴포넌트 최상단에서 key를 적용해야 한다.

+ Warning: validateDOMNesting(...): &lt;p&gt; cannot appear as a descendant of &lt;p&gt;.
=> &lt;p&gt;의 자식으로 &lt;p&gt; 태그가 들어갈 수 없다. &lt;p&gt;의 자식으로 &lt;div&gt; 태그가 들어갈 수 없다.

