### PR TITLE
FIX: Introduce Warning 해결

### DIFF
--- a/src/Pages/Introduce.js
+++ b/src/Pages/Introduce.js
@@ -62,7 +62,7 @@ const Introduce = () => {
                         <Directions>
                             <WrapWay>
                                 <LabelWay>
-                                    <Way type="radio" name="map" value="map_front" onClick={onClick} style={{appearance: "none"}} checked/>
+                                    <Way type="radio" name="map" value="map_front" onClick={onClick} style={{appearance: "none"}} defaultChecked/>
                                     <span style={selectMap === "map_front" ? {color: "#000000"} : {color: "#989898"}}>수의과대학 (정문)</span>
                                 </LabelWay>
                                 <LabelWay>


### PR DESCRIPTION
+ Warning: Failed prop type: You provided a checked prop to a form field without an onChange handler. This will render a read-only field. If the field should be mutable use defaultChecked. Otherwise, set either onChange or readOnly.
=> onClick과 checked 동시 사용 불가. defaultChecked로 수정